### PR TITLE
execute pre-commit checks on PR only

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -1,12 +1,12 @@
 name: Static code analysis
 
 on:
-  # pull_request:
+  pull_request:
+    paths-ignore:
+      - "**.svg"
+  # push:
   #   # paths-ignore:
   #   #   - "**.md"
-  push:
-    # paths-ignore:
-    #   - "**.md"
 
 jobs:
   tools:


### PR DESCRIPTION
## What changes does your PR bring?

Reduce the number of `static analysis checks` by executing them only when PR is being created. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## References

Fixes: https://github.com/opsd-io/terraform-module-template/issues/38

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
