### PR TITLE
Add chore type of change to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,14 +5,13 @@ In a few words, describe what changes your commits make to the code.
 ## Type of change
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Chore (non-breaking change to the build process or auxiliary tools)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
 
 ## References
 
-Fixes: paste the issue link here
-
-Add any other links important from the point of view of your Pull Request here.
+Fixes:
 
 # Checklist:
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,11 +31,11 @@ version-resolver:
   minor:
     labels:
       - 'enhancement'
+      - 'chore'
   patch:
     labels:
       - 'bug'
       - 'documentation'
-      - 'chore'
 
 exclude-labels:
   - 'skip-changelog'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,6 +35,7 @@ version-resolver:
     labels:
       - 'bug'
       - 'documentation'
+      - 'chore'
 
 exclude-labels:
   - 'skip-changelog'


### PR DESCRIPTION
## What changes does your PR bring?

Adding `chore` type of change to the PR template. Chore changes will bump the minor release version. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## References

Fixes: https://github.com/opsd-io/terraform-module-template/issues/40

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
