### PR TITLE
Adding documentation type of change to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ In a few words, describe what changes your commits make to the code.
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Chore (non-breaking change to the build process or auxiliary tools)
 - [ ] New feature (non-breaking change which adds functionality)
+- [ ] Documentation (Improvements or additions to documentation)
 - [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
 
 ## References


### PR DESCRIPTION
## What changes does your PR bring?

Adding `documentation` type of change to the PR template

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change to the build process or auxiliary tools)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## References

Fixes: https://github.com/opsd-io/terraform-module-template/issues/39

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
