### PR TITLE
chore tasks should be treated as patches by the release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,11 +31,11 @@ version-resolver:
   minor:
     labels:
       - 'enhancement'
-      - 'chore'
   patch:
     labels:
       - 'bug'
       - 'documentation'
+      - 'chore'
 
 exclude-labels:
   - 'skip-changelog'


### PR DESCRIPTION
## What changes does your PR bring?

`chore` changes should be treated as patches by the release-drafter

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change to the build process or auxiliary tools)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (Improvements or additions to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## References

Fixes: https://github.com/opsd-io/terraform-module-template/issues/48

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
